### PR TITLE
Add authenticated Axios instance with request interceptor.

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,7 +1,17 @@
 import axios from "axios";
 
+import * as SecureStore from "expo-secure-store";
+
 const API = axios.create({
-  baseURL: "http://10.254.202.225:3000",   //your LAN IP
+  baseURL: "http://11.6.2.181:3000",   //your LAN IP
+});
+
+API.interceptors.request.use(async (config) => {
+  const token = await SecureStore.getItemAsync("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
 });
 
 export default API;


### PR DESCRIPTION
So basically
* Before sending any request, we are going to get the saved token 
* If the token exists, add it to the request so the server knows who the user is

**If to elaborate**
* It gets the token stored on the device.
* It adds that token into the request headers.
* the server can check:  
 --  who you are 
 --  if you’re logged in 
 -- if you have permission